### PR TITLE
feat: Add 'limit' of contexts to return in simple search

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1550,6 +1550,13 @@ paths:
           schema:
             default: 100
             type: "number"
+        - description: "How many contexts to return at most"
+          in: "query"
+          name: "limit"
+          required: false
+          schema:
+            default: 100
+            type: "number"
       responses:
         "200":
           content:

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -186,9 +186,9 @@ class Obsidian:
 
         return "".join(result)
 
-    def search(self, query: str, context_length: int = 100) -> Any:
+    def search(self, query: str, context_length: int = 100, limit: int = 100) -> Any:
         url = f"{self.get_base_url()}/search/simple/"
-        params = {"query": query, "contextLength": context_length}
+        params = {"query": query, "contextLength": context_length, "limit": limit}
 
         def call_fn():
             response = requests.post(


### PR DESCRIPTION
Thanks for maintaining a fork. :sparkling_heart: 

In my vault, the search often leads to lots of results - especially if a few files contain the same search term many many times (as I have them). This PR adds a feature to limit the number of maximum contexts which will be returned. Hence, the MCP caller always knows, that the output will be in the order of ~O(context_length * limit) characters - which is itself also correlated to the number of tokens. This makes the tool calls more predictable in context length.

What do you think?
