### PR TITLE
Discussion of features: get backlinks, get file contents by note name, readonly mode, query filenames in entire vault

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1555,7 +1555,7 @@ paths:
           name: "limit"
           required: false
           schema:
-            default: 100
+            default: 1000
             type: "number"
       responses:
         "200":

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -188,6 +188,9 @@ class Obsidian:
         return self._safe_call(call_fn)
 
     def get_file_contents_by_name(self, name: str) -> Any:
+        if "/" in name:
+            name = name.split("/")[-1] # remove path-parts. Agents may include this by mistake, but we can be friendly here
+
         files = self.list_all_files_in_vault_recursively(".", name)
 
         # file_name_in_file_path_is_name("some/path/"+name+".md") => true

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -147,6 +147,9 @@ class Obsidian:
 
         return self._safe_call(call_fn)
 
+    def query_files_recursively(self, query: str) -> Any:
+        return self.list_all_files_in_vault_recursively(".", query)
+
     # walks though all directories in the vault recursively and returns a list of all filepaths containing the query term
     def list_all_files_in_vault_recursively(self, directory: str, query: str) -> Any:
         if not directory.endswith("/"):

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -231,7 +231,7 @@ class Obsidian:
 
         return "".join(result)
 
-    def search(self, query: str, context_length: int = 100, limit: int = 100) -> Any:
+    def search(self, query: str, context_length: int = 100, limit: int = 1000) -> Any:
         url = f"{self.get_base_url()}/search/simple/"
         params = {"query": query, "contextLength": context_length, "limit": limit}
 

--- a/src/mcp_obsidian/obsidian.py
+++ b/src/mcp_obsidian/obsidian.py
@@ -164,7 +164,7 @@ class Obsidian:
                 rec_files = self.list_all_files_in_vault_recursively(directory + file_or_dir, query)
                 directory_name_prepended = map(lambda f: file_or_dir + f, rec_files)
                 files.extend( directory_name_prepended )
-            elif query in file_or_dir:
+            elif query.lower() in file_or_dir.lower(): # case-insensitive match
                 # add normal file satisfying query to files list
                 files.append(file_or_dir)
 

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -49,6 +49,7 @@ def get_tool_handler(name: str) -> tools.ToolHandler | None:
 
 add_tool_handler(tools.ListFilesInDirToolHandler())
 add_tool_handler(tools.ListFilesInVaultToolHandler())
+add_tool_handler(tools.QueryFilesRecursivelyToolHandler())
 add_tool_handler(tools.GetFileContentsToolHandler())
 add_tool_handler(tools.GetFileContentsByNameToolHandler())
 add_tool_handler(tools.SearchToolHandler())

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -50,6 +50,7 @@ def get_tool_handler(name: str) -> tools.ToolHandler | None:
 add_tool_handler(tools.ListFilesInDirToolHandler())
 add_tool_handler(tools.ListFilesInVaultToolHandler())
 add_tool_handler(tools.GetFileContentsToolHandler())
+add_tool_handler(tools.GetFileContentsByNameToolHandler())
 add_tool_handler(tools.SearchToolHandler())
 add_tool_handler(tools.PatchContentToolHandler())
 add_tool_handler(tools.AppendContentToolHandler())

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -52,10 +52,14 @@ add_tool_handler(tools.ListFilesInVaultToolHandler())
 add_tool_handler(tools.GetFileContentsToolHandler())
 add_tool_handler(tools.GetFileContentsByNameToolHandler())
 add_tool_handler(tools.SearchToolHandler())
-add_tool_handler(tools.PatchContentToolHandler())
-add_tool_handler(tools.AppendContentToolHandler())
-add_tool_handler(tools.PutContentToolHandler())
-add_tool_handler(tools.DeleteFileToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.PatchContentToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.AppendContentToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.PutContentToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.DeleteFileToolHandler())
 add_tool_handler(tools.ComplexSearchToolHandler())
 add_tool_handler(tools.BatchGetFileContentsToolHandler())
 add_tool_handler(tools.PeriodicNotesToolHandler())
@@ -63,8 +67,25 @@ add_tool_handler(tools.RecentPeriodicNotesToolHandler())
 add_tool_handler(tools.RecentChangesToolHandler())
 add_tool_handler(tools.DataviewQueryToolHandler())
 add_tool_handler(tools.GetActiveNoteToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.AppendToActiveToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.ReplaceActiveNoteToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.PatchActiveNoteToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.DeleteActiveNoteToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.AppendToPeriodicToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.ReplacePeriodicNoteToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.PatchPeriodicNoteToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.DeletePeriodicNoteToolHandler())
 add_tool_handler(tools.ListCommandsToolHandler())
-add_tool_handler(tools.ExecuteCommandToolHandler())
+if not tools.read_only_mode:
+    add_tool_handler(tools.ExecuteCommandToolHandler())
 add_tool_handler(tools.OpenFileToolHandler())
 
 

--- a/src/mcp_obsidian/server.py
+++ b/src/mcp_obsidian/server.py
@@ -67,6 +67,7 @@ add_tool_handler(tools.PeriodicNotesToolHandler())
 add_tool_handler(tools.RecentPeriodicNotesToolHandler())
 add_tool_handler(tools.RecentChangesToolHandler())
 add_tool_handler(tools.DataviewQueryToolHandler())
+add_tool_handler(tools.GetBacklinksToNoteToolHandler())
 add_tool_handler(tools.GetActiveNoteToolHandler())
 if not tools.read_only_mode:
     add_tool_handler(tools.AppendToActiveToolHandler())

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -189,13 +189,13 @@ class GetFileContentsByNameToolHandler(ToolHandler):
     def get_tool_description(self):
         return Tool(
             name=self.name,
-            description="Return the contents of a single file in your vault by the note-name. Use this to links to 'Note Name.md' such as [[Note Name]] or [[Note Name|My Note Alias]] or [[Note Name#some-note-section-heading]] or [[Note Name^some-block-reference]]. The note name is always the part before the '|' or ']]' or '#' or '^'.",
+            description="Return the contents of a single file in your vault by the note-name. Use this to links to 'Note Name.md' such as [[Note Name]] or [[Note Name|My Note Alias]] or [[Note Name#some-note-section-heading]] or [[Note Name^some-block-reference]]. The note name is always the part before the '|' or ']]' or '#' or '^'. Any path part will be ignored.",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "Name of the file to open (without the '.md'; case-sensitive)"
+                        "description": "Name of the file to open (without the '.md'; case-sensitive)."
                     },
                 },
                 "required": ["name"],

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -115,7 +115,7 @@ class QueryFilesRecursivelyToolHandler(ToolHandler):
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "The search term to query for in the file names (case-insensitive)",
+                        "description": "The text to search for in file names (case-insensitive). E.g. 'dwarf' will match 'Astronomy/Brown Dwarfs.md'.",
                     },
                 },
                 "required": ["query"],
@@ -155,7 +155,7 @@ class GetFileContentsToolHandler(ToolHandler):
                 "properties": {
                     "filepath": {
                         "type": "string",
-                        "description": "Path to the relevant file (relative to your vault root).",
+                        "description": "Path to the relevant file (relative to your vault root). E.g. 'Astronomy/Brown Dwarfs.md'",
                         "format": "path",
                     },
                 },
@@ -195,7 +195,7 @@ class GetFileContentsByNameToolHandler(ToolHandler):
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "Name of the file to open (without the '.md'; case-sensitive)."
+                        "description": "Name of the file to open (without the '.md'; case-sensitive). E.g. 'Brown Dwarfs' to open file 'Astronomy/Brown Dwarfs.md'."
                     },
                 },
                 "required": ["name"],

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -103,6 +103,45 @@ class ListFilesInDirToolHandler(ToolHandler):
             )
         ]
 
+class QueryFilesRecursivelyToolHandler(ToolHandler):
+    def __init__(self):
+        super().__init__("obsidian_query_files_recursively")
+
+    def get_tool_description(self):
+        return Tool(
+            name=self.name,
+            description="Lists all files (recursively inside the entire vault) which contain 'query' in filename.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search term to query for in the file names",
+                    },
+                },
+                "required": ["query"],
+            },
+            annotations=ToolAnnotations(
+                title="Query Files Recursively",
+                readOnlyHint=True,
+            ),
+        )
+
+    def run_tool(
+        self, args: dict
+    ) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
+        if "query" not in args:
+            raise RuntimeError("query argument missing in arguments")
+
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+
+        files = api.query_files_recursively(args["query"])
+
+        return [
+            TextContent(
+                type="text", text=json.dumps(files, indent=2, ensure_ascii=False)
+            )
+        ]
 
 class GetFileContentsToolHandler(ToolHandler):
     def __init__(self):
@@ -111,7 +150,7 @@ class GetFileContentsToolHandler(ToolHandler):
     def get_tool_description(self):
         return Tool(
             name=self.name,
-            description="Return the content of a single file in your vault.",
+            description="Return the content of a single file in your vault. Use 'obsidian_get_file_contents_by_name' instead, if only the filename but not the filepath is known.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -151,13 +190,13 @@ class GetFileContentsByNameToolHandler(ToolHandler):
     def get_tool_description(self):
         return Tool(
             name=self.name,
-            description="Return the contents of a single file in your vault by the note-name. Useful to open links such as [[note-name]] or [[note-name|note-alias]].",
+            description="Return the contents of a single file in your vault by the note-name. USe this to links such as [[Note Name]] or [[Note Name|My Note Alias]].",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "Name of the file to open"
+                        "description": "Name of the file to open (without the '.md')"
                     },
                 },
                 "required": ["name"],

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -143,6 +143,45 @@ class GetFileContentsToolHandler(ToolHandler):
             )
         ]
 
+class GetFileContentsByNameToolHandler(ToolHandler):
+    def __init__(self):
+        super().__init__("obsidian_get_file_contents_by_name")
+
+    def get_tool_description(self):
+        return Tool(
+            name=self.name,
+            description="Return the contents of a single file in your vault by the note-name. Useful to open links such as [[note-name]] or [[note-name|note-alias]].",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the file to open"
+                    },
+                },
+                "required": ["name"],
+            },
+            annotations=ToolAnnotations(
+                title="Get File Contents by Name",
+                readOnlyHint=True,
+            ),
+        )
+    
+    def run_tool(
+        self, args: dict
+    ) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
+        if "name" not in args:
+            raise RuntimeError("name argument missing in arguments")
+
+        api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
+
+        content = api.get_file_contents_by_name(args["name"])
+
+        return [
+            TextContent(
+                type="text", text=json.dumps(content, indent=2, ensure_ascii=False)
+            )
+        ]
 
 class SearchToolHandler(ToolHandler):
     def __init__(self):

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -260,7 +260,7 @@ class SearchToolHandler(ToolHandler):
             raise RuntimeError("query argument missing in arguments")
 
         context_length = args.get("context_length", 100)
-        limit = args.get("limit", 100)
+        limit = args.get("limit", 1000)
         
         api = obsidian.Obsidian(api_key=api_key, host=obsidian_host)
         results = api.search(args["query"], context_length, limit)

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -12,6 +12,7 @@ from . import obsidian
 
 api_key = os.getenv("OBSIDIAN_API_KEY", "")
 obsidian_host = os.getenv("OBSIDIAN_HOST", "127.0.0.1")
+read_only_mode = int(os.getenv("OBSIDIAN_READONLY", "0")) == 1
 
 if api_key == "":
     raise ValueError(

--- a/src/mcp_obsidian/tools.py
+++ b/src/mcp_obsidian/tools.py
@@ -116,7 +116,7 @@ class QueryFilesRecursivelyToolHandler(ToolHandler):
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "The search term to query for in the file names",
+                        "description": "The search term to query for in the file names (case-insensitive)",
                     },
                 },
                 "required": ["query"],
@@ -190,13 +190,13 @@ class GetFileContentsByNameToolHandler(ToolHandler):
     def get_tool_description(self):
         return Tool(
             name=self.name,
-            description="Return the contents of a single file in your vault by the note-name. USe this to links such as [[Note Name]] or [[Note Name|My Note Alias]].",
+            description="Return the contents of a single file in your vault by the note-name. Use this to links such as [[Note Name]] or [[Note Name|My Note Alias]].",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "Name of the file to open (without the '.md')"
+                        "description": "Name of the file to open (without the '.md'; case-sensitive)"
                     },
                 },
                 "required": ["name"],


### PR DESCRIPTION
Hi @ernestkoe ,

While using mcp-obsidian, with my local LLMs (unsloth gpt-oss-120B) I came across a few things which I feel are lacking and which *are very useful* for LLM agents to be able to use. I primarily use this MCP server to let my LLM agent summarize an aspect of my life by reading through many related notes and then creating a ~2k token summary - which can then be used by other agents to understand this aspect of my life (without pulluting their context with details from the obsidian vault)

This PR is a draft, because I want to first discuss these features with you. The features are simply implemented in a way which works for me - and they're a bit hacky. Hence I want to discuss with you how to best integrate/refactor/change which features. For the features, I've also not updated the documentation. I've only added the minimal code to make it work for my own use case for prototyping.

I added the following main features:
* obsidian_get_file_contents_by_name. This allows the agent to open links such as `[[Brown Dwarf]]` which it encounters while reading notes. Previously, one had to use obsidian_get_file_contents, but that one required one to use full path to the note - e.g. `Astronomy/Brown Dwarf.md`. However, if you only see the link in a note, you *don't know the path of the file*, so the agent couldn't ever open it. Perhaps we can refactor this to be part of the normal obsidian_get_file_contents, where the MCP server falls back on searching by note name if the exact filepath wasn't found.
* obsidian_query_files_recursively. This effectively simulates the `Quick Switcher` behavior via Ctrl+O. By providing a word, one can quickly find notes which have the word in their filenames. E.g. `dwarf` could return a list of `Astronomy/Brown Dwarf.md` and `Fantasy/Dwarf.md`. My agents also use this extensively.
* obsidian_backlinks_to_note. A cornerstone of obsidian. I love this feature when using Obsidian - so I can see which other notes link back to the current note. Giving the agent this tool enables them to look for notes which reference relevant notes - and make good use of that. It's also related to how we as humans navigate the vault. Unfotunately, there is no obsidian local rest API endpoint for that, so I made a hack and use a dataview query to implement this. The cleanest implementation would be to add a new endpoint to the rest API, however, that is more effort and would require communication with them to have it merged eventually.
* readonly mode. when connecting one's obsidian vault to a MCP server, it's best to have the option to ensure that the agent can be restricted to not modify the vault. When importing the MCP server into langflow, it kinda scared me, that I needed to previously to manually disable the destructive operations. Furthermore, when re-importing the MCP server etc, sometimes it just forgot them and re-enabled these tools! Hence, I disabled them via an env-variable. 
<img width="480" height="505" alt="image" src="https://github.com/user-attachments/assets/e65b62ae-d023-4f63-b4c9-b8288fa7c557" />

* forgiving behavior. It happens sometimes, that the agents mistakenly use a filepath where a note name was required - or don't add a trailing slash '/' for directories. In such cases, I've adapted a few edge cases so that the MCP server is forgiving. For usual software engineering, such behavior isn't desires, but for LLMs this makes sense as it's better to not pollute the context with failed attempts and occasional re-attempts.

What do you think?

~💖